### PR TITLE
Add detection for unsupported Broadlink devices.

### DIFF
--- a/broadlink_bridge/__init__.py
+++ b/broadlink_bridge/__init__.py
@@ -110,6 +110,10 @@ class Device:
             except (socket.gaierror, socket.timeout):
                 pass
 
+            if connected and self._dev.get_type() == 'Unknown':
+                LOGGER.warning('Device type %s unsupported by python-broadlink module' % hex(self._dev.devtype))
+                connected = False
+
             if connected:
                 self._mac = mac_format(self._dev.mac, reverse=True)
                 self._addresses = get_ip_addresses(self._dev.host[0])

--- a/broadlink_bridge/mqtt.py
+++ b/broadlink_bridge/mqtt.py
@@ -29,8 +29,8 @@ def mqtt_transmit(client, userdata, msg):
     try:
         if device.transmit(code):
             return
-    except:
-        pass
+    except Exception as error:
+        LOGGER.warning('MQTT %s: transmit failed: %s', msg.topic, str(error))
     LOGGER.warning('MQTT %s: invalid payload', msg.topic)
 
 def mqtt_connect(url, prefix='broadlink'):


### PR DESCRIPTION
The code that sets up a connection to a Broadlink device, now detects when the device type is reported as 'Unknown'. In such case, the library can talk to the device, but the device itself is not (yet) recognized by the python-broadlink module.

The warning that now is shown in such case, includes the device ID that will have to be added to the broadlink.SUPPORTED_TYPES dict.

This change also includes improved logging for mqtt_transmit(). When the internal call to device.transmit() raises an Exception, then the Exception message is logged as a warning. This warning is what initially lead me to the issue with unsupported devices.