### PR TITLE
Configurable Broadlink device types

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -11,6 +11,26 @@ denon/power-on = 0000 006D 0000 0020 000A 001E 000A 0046 000A 001E 000A 001E 000
 # For example, the code below will be sent 5 times (4 repeats):
 panasonic/power-on = 5 * 0000 0070 0000 0032 0080 0040 0010 0010 0010 0030 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0030 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0030 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0030 0010 0030 0010 0030 0010 0030 0010 0030 0010 0010 0010 0010 0010 0010 0010 0030 0010 0030 0010 0030 0010 0030 0010 0030 0010 0010 0010 0030 0010 0ACD
 
+[device_types]
+# Most devices are supported by default through the python-broadlink
+# module. When new device types are introduced which are not (yet)
+# supported by the module, they can be configured here.
+#
+# The format is: <device type id> = <class>, <name>, <brand>
+#
+# <device type id>: the hexadecimal device type id (e.g. "0x6539")
+# <class>: name of the python-broadlink implementation class (e.g "rm" or "rm4")
+# <name>: can be chosen freely, e.g. "RM4 mini"
+# <brand>: normally "Broadlink"
+0x27D3 = rm,  RM mini 3, Broadlink
+0x6539 = rm4, MR4C mini, Broadlink
+0x6539 = rm4, RM4C mini, Broadlink
+0x6508 = rm4, RM mini 3, Broadlink
+0x6539 = rm4, RM4C mini, Broadlink
+0x6364 = rm4, RM4S,      Broadlink
+0x653C = rm4, RM4 pro,   Broadlink
+0x653C = rm4, RM4 pro,   Broadlink
+
 [devices]
 # Known devices that will be exposed via the bridge.
 # The key is the alias that the device can be addressed as.


### PR DESCRIPTION
Broadlink devices have a device type identifier, which defines what type of device it is. These identifiers are used by the python-broadlink module to determine what kind of devices it is handling.
Sometimes, new identifiers are used for existing hardware, e.g. because the manufacturer has changed. In such case, the python-broadlink module has to be updated with the new identifiers to make things work.
This change allows a user to define additional device types in the broadlink-bridge config.in file, which makes it possible to use new device types even before the python-broadlink module code has been updated.